### PR TITLE
stop Quagga on umount, rather than product found

### DIFF
--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -16,7 +16,6 @@ const Video = ({ history }) => {
   const [ barcode, setBarcode ] = useState(null);
 
   const onProductFound = (code) => {
-    Quagga.stop();
     if (code === 'not-found') {
       history.push(`/product/${code}?code=${barcode}`);
     } else {
@@ -70,7 +69,9 @@ const Video = ({ history }) => {
           onInitSuccess();
       });
       Quagga.onDetected(onDetected);
+      return () => Quagga.stop();
     }
+    return undefined;
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Quagga remains running when Video unmounts, unless it is unmounted via finding a product (including the `not-found` "product"). If the user navigates to history, for example, Quagga is left running. `useEffect`'s unsubscribe handler is a better choice.